### PR TITLE
fix: quotes in arguments maybe ignored on arm64-Darwin.

### DIFF
--- a/arm64-Darwin/gdb
+++ b/arm64-Darwin/gdb
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 d=$(dirname $(dirname "$0"))
-PYTHONHOME=$d x86_64-linux-gnu-gdb $*
+PYTHONHOME=$d x86_64-linux-gnu-gdb "$@"


### PR DESCRIPTION
The patch fixed the command line issue,

```
 Excess command line arguments ignored. (tsr)
```

replaced '$*' by '$@' to keep all the quotes in arguments.